### PR TITLE
Disable text fields if there's an appointment number.

### DIFF
--- a/frontend/src/components/AppointmentForm.vue
+++ b/frontend/src/components/AppointmentForm.vue
@@ -285,6 +285,7 @@ export default {
       this.$store.dispatch('startRebooking')
     },
     stopRebooking() {
+      console.log("stopRebooking")
       this.$store.dispatch('stopRebooking')
     },
     startOver() {

--- a/frontend/src/components/AppointmentForm.vue
+++ b/frontend/src/components/AppointmentForm.vue
@@ -285,7 +285,6 @@ export default {
       this.$store.dispatch('startRebooking')
     },
     stopRebooking() {
-      console.log("stopRebooking")
       this.$store.dispatch('stopRebooking')
     },
     startOver() {

--- a/frontend/src/components/CustomerInfo.vue
+++ b/frontend/src/components/CustomerInfo.vue
@@ -1,14 +1,15 @@
 <template>
   <div>
     <div id="customer-name-section">
-      <v-text-field v-model="customer.name" id="customer-name" :error-messages="nameErrors" @input="$v.name.$touch()"
-        @blur="$v.name.$touch()" @change="changed" counter="50" filled :label="$t('name')"></v-text-field>
+      <v-text-field v-model="customer.name" id="customer-name" :error-messages="nameErrors" 
+        @input="$v.name.$touch()" @blur="$v.name.$touch()" @change="changed" 
+        counter="50" filled :label="$t('name')" :disabled="isPreselectedAppointment"></v-text-field>
     </div>
 
     <div id="customer-email-section">
-      <v-text-field v-model="customer.email" id="customer-email" counter="50" filled :error-messages="emailErrors"
-        @input="$v.email.$touch()" @blur="$v.email.$touch()" @change="changed" required
-        :label="$t('email')"></v-text-field>
+      <v-text-field v-model="customer.email" id="customer-email" counter="50" filled 
+        :error-messages="emailErrors" @input="$v.email.$touch()" @blur="$v.email.$touch()" 
+        @change="changed" required :label="$t('email')" :disabled="isPreselectedAppointment"></v-text-field>
     </div>
 
     <v-checkbox id="customer-data-protection" v-model="customer.dataProtection" label=""
@@ -98,6 +99,10 @@ export default {
       !this.customer.dataProtection && errors.push(this.$t('acceptPrivacyPolicy'));
 
       return errors;
+    },
+    isPreselectedAppointment() {
+      
+      return this.$store.state.preselectedAppointment !== null;
     }
   },
   methods: {

--- a/frontend/src/store/actions.js
+++ b/frontend/src/store/actions.js
@@ -146,7 +146,6 @@ export default {
         store.state.confirmedAppointment = true
 
         store.commit('selectProviderWithId', store.state.preselectedAppointment.providerId)
-        //store.commit('data/setCustomerData', store.state.preselectedAppointment.customer)
         store.commit('data/setAppointment', store.state.preselectedAppointment)
     }
 }

--- a/frontend/src/store/actions.js
+++ b/frontend/src/store/actions.js
@@ -146,7 +146,7 @@ export default {
         store.state.confirmedAppointment = true
 
         store.commit('selectProviderWithId', store.state.preselectedAppointment.providerId)
-        store.commit('data/setCustomerData', store.state.preselectedAppointment.customer)
+        //store.commit('data/setCustomerData', store.state.preselectedAppointment.customer)
         store.commit('data/setAppointment', store.state.preselectedAppointment)
     }
 }


### PR DESCRIPTION
**Description**

Die Textfelder für Name und E-Mail sind bei Umbuchungen jetzt deaktiviert. Also wenn ein Termin true ist.

**Reference**

Issues #1226 #968