### PR TITLE
bugfix(ZMSKVR-417): incorrect display of available slots

### DIFF
--- a/frontend/src/components/TheCalendar.vue
+++ b/frontend/src/components/TheCalendar.vue
@@ -365,6 +365,7 @@ export default {
     showForProvider: function (provider) {
       this.errorKey = ''
       this.dateError = false
+      this.timeDialog = false
       this.timeSlotError = false
 
       this.provider = provider
@@ -419,6 +420,7 @@ export default {
 
           const availableDays = data.availableDays ?? []
           if (availableDays.length > 0) {
+            this.timeDialog = true
             this.selectableDates = availableDays
             this.getAppointmentsOfDay(availableDays[0], false)
           }


### PR DESCRIPTION
The `timeDialog` flag, which controls whether slots are displayed or not, was previously only changed when available-appointments was called. If there were slots available at a certain office, `timeDialog` was set to `true`. When changing to another office (office change triggers available-days), where there were no available days, `timeDialog` remained `true` and was not reset to `false`, which caused the slots of the previous office to be displayed. Adding the `timeDialog` logic to the available-days call solves this problem.